### PR TITLE
added return statement in FittedPeak._create

### DIFF
--- a/ms_peak_picker/_c/peak_set.pyx
+++ b/ms_peak_picker/_c/peak_set.pyx
@@ -42,6 +42,8 @@ cdef class FittedPeak(object):
         inst.index = index
         inst.area = area
 
+        return inst
+
     cpdef FittedPeak clone(self):
         return FittedPeak._create(
             self.mz, self.intensity, self.signal_to_noise,


### PR DESCRIPTION
There's a missing return statement in C-implemented `FittedPeak._create`
This causes `.clone()` to return None instead of a new instance, e.g.:

```python
import ms_peak_picker
args = (1.23, 4.56, 7.89, 1, 1, 0.1, 13)
fp = ms_peak_picker.peak_set.FittedPeak(*args)

print('fp.clone(): {!r}'.format(fp.clone()))
```

results in 

```
fp.clone(): None
```

Adding a return statement, obviously, fixes this:

```
fp.clone(): FittedPeak(mz=1.230, intensity=4.560, signal_to_noise=7.890, peak_count=1, index=1, full_width_at_half_max=0.100, area=13.000)
```